### PR TITLE
Find protocolViewer for Kovan

### DIFF
--- a/lib/setJsApi.ts
+++ b/lib/setJsApi.ts
@@ -20,10 +20,8 @@ export const KOVAN_SET_ADDRESSES: SetAddresses = {
     // https://docs.tokensets.com/contracts/deployed/protocol it is listed as
     // PriceOracle. Resolve the discrepancy so future devs aren't confused.
     masterOracle: "0xDFEA02F2824Ee177733d6f108005E95C85D1D4bE",
-    navIssuance: "https://kovan.etherscan.io/address/0x5dB52450a8C0eb5e0B777D4e08d7A93dA5a9c848",
-    // protocolViewer doesn't exist on https://docs.tokensets.com/contracts/deployed/protocol
-    // Kovan won't work until this field is populated
-    protocolViewer: "",
+    navIssuance: "0x5dB52450a8C0eb5e0B777D4e08d7A93dA5a9c848",
+    protocolViewer: "0xbbC86C6099B148383941e8E592847fDC61a03283",
     setTokenCreator: "0xB24F7367ee8efcB5EAbe4491B42fA222EC68d411",
     streamingFee: "0xE038E59DEEC8657d105B6a3Fb5040b3a6189Dd51",
     tradeModule: "0xC93c8CDE0eDf4963ea1eea156099B285A945210a"


### PR DESCRIPTION
This was ridiculous to find. The contract address doesn't exist on
https://docs.tokensets.com/contracts/deployed/protocol so I inspected
the mainnet protocol viewer
https://etherscan.io/address/0x74391125304f1e4ce11bDb8aaAAABcF3A3Ae2f41
and observed it was deployed approx 208 days ago. I went to Kovan
explorer and found Set deployer contract
https://kovan.etherscan.io/txs?a=0x69bdb276a17dd90f9d3a545944ccb20e593ae8e3&f=5&p=3
then went back in time until I found contracts deployed ~208 days.
Unfrotunately the ProtocolViewer doesn't show up as verified source with
a name but there were only a few contracts that lined up with the right
time period so I brute force started trying them